### PR TITLE
Updated install folder picker code to accept "minecraft"

### DIFF
--- a/SkyblockClient/FrmAdvancedSettings.xaml.cs
+++ b/SkyblockClient/FrmAdvancedSettings.xaml.cs
@@ -55,13 +55,22 @@ namespace SkyblockClient
 			CommonOpenFileDialog dialog = new CommonOpenFileDialog();
 
 			string initialDirectory = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
-			if (Directory.Exists(Path.Combine(initialDirectory, ".minecraft")))
+			string dotMinecraftPath = Path.Combine(initialDirectory, ".minecraft");
+			string minecraftPath = Path.Combine(initialDirectory, "minecraft");
+
+			// Set initial directory to .minecraft or minecraft if either exists
+			if (Directory.Exists(dotMinecraftPath))
 			{
-				initialDirectory = Path.Combine(initialDirectory, ".minecraft");
+				initialDirectory = dotMinecraftPath;
 			}
+    		else if (Directory.Exists(minecraftPath))
+    		{
+        		initialDirectory = minecraftPath;
+    		}
 
 			dialog.InitialDirectory = initialDirectory;
 			dialog.IsFolderPicker = true;
+
 			if (dialog.ShowDialog() == CommonFileDialogResult.Ok)
 			{
 				bool valid = Utils.ValidateMinecraftDirectory(dialog.FileName);


### PR DESCRIPTION
Hello! Ive noticed that the file picker dialog will return an error if the chosen directory is named "minecraft", which is what some other launchers choose to name their minecraft directory versus .minecraft (such as prism launcher).

Ive made an edit to the logic that decides whether the folder is valid or not that I believe will fix the issue, however I am not too familiar with working on c# projects and am unsure how to locally build and test the changes myself. Any assistance building the project or fixing my changes would be very helpful.